### PR TITLE
Add Snakemake workflow for ChIP-seq processing

### DIFF
--- a/ChIPSeq/README.md
+++ b/ChIPSeq/README.md
@@ -1,0 +1,47 @@
+# ChIP-seq Snakemake Pipeline
+
+This pipeline automates a standard ChIP-seq analysis workflow, starting with data retrieval from the SRA and ending with peak calling using MACS2. Update the configuration file before running the workflow.
+
+## Requirements
+
+Ensure the following tools are installed and available in your `$PATH`:
+
+- [SRA Toolkit](https://github.com/ncbi/sra-tools) providing `fasterq-dump`
+- [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
+- [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml)
+- [SAMtools](http://www.htslib.org/)
+- [MACS2](https://github.com/macs3-project/MACS)
+- [Snakemake](https://snakemake.readthedocs.io/en/stable/)
+
+## Configuration
+
+Edit `config.yaml` to match your experiment:
+
+- `threads`: number of CPU threads to allocate for multithreaded steps.
+- `directories`: destination folders for intermediate and final outputs. They will be created automatically.
+- `reference.bowtie2_index`: prefix to the Bowtie2 genome index (built with `bowtie2-build`).
+- `macs2`: parameters passed to MACS2 peak calling.
+- `samples`: dictionary keyed by internal sample IDs with their corresponding SRA accessions.
+- `pairs`: mapping between ChIP treatment and matched control samples. The keys are used to name the final peak outputs.
+
+## Running the pipeline
+
+1. Change into the `ChIPSeq` directory.
+2. Review and edit `config.yaml` to include the desired SRA accessions, reference index, and output paths.
+3. Execute Snakemake, specifying a desired level of parallelism:
+
+   ```bash
+   snakemake --use-conda --cores 8
+   ```
+
+   Remove `--use-conda` if you prefer to manage dependencies globally.
+
+The workflow performs the following steps for each sample:
+
+1. **Download SRA reads** with `fasterq-dump` (paired-end reads are split and compressed).
+2. **Quality control** using FastQC.
+3. **Alignment** of reads to the reference genome with Bowtie2, producing sorted BAM files.
+4. **Duplicate removal** with `samtools markdup` and BAM indexing.
+5. **Peak calling** with MACS2 using the ChIP/Input pairs defined in the configuration.
+
+The final peaks are located in `results/peaks/<pair>/<pair>_peaks.narrowPeak`.

--- a/ChIPSeq/Snakefile
+++ b/ChIPSeq/Snakefile
@@ -1,0 +1,105 @@
+import os
+
+configfile: "config.yaml"
+
+FASTQ_DIR = config["directories"]["fastq"]
+ALIGN_DIR = config["directories"]["aligned"]
+PEAK_DIR = config["directories"]["peaks"]
+
+SAMPLES = config["samples"]
+PAIRS = config["pairs"]
+
+rule all:
+    input:
+        expand(os.path.join(PEAK_DIR, "{pair}", "{pair}_peaks.narrowPeak"), pair=PAIRS.keys()),
+        expand(os.path.join(FASTQ_DIR, "qc", "{sample}_1_fastqc.html"), sample=SAMPLES.keys()),
+        expand(os.path.join(FASTQ_DIR, "qc", "{sample}_2_fastqc.html"), sample=SAMPLES.keys())
+
+rule download_fastq:
+    output:
+        fq1=os.path.join(FASTQ_DIR, "{sample}_1.fastq.gz"),
+        fq2=os.path.join(FASTQ_DIR, "{sample}_2.fastq.gz")
+    params:
+        accession=lambda wildcards: SAMPLES[wildcards.sample]["sra"]
+    threads: config.get("threads", 8)
+    shell:
+        """
+        mkdir -p {FASTQ_DIR}
+        fasterq-dump --split-files --threads {threads} --outdir {FASTQ_DIR} {params.accession}
+        gzip -f {FASTQ_DIR}/{wildcards.sample}_1.fastq
+        gzip -f {FASTQ_DIR}/{wildcards.sample}_2.fastq
+        """
+
+rule fastqc:
+    input:
+        fq1=os.path.join(FASTQ_DIR, "{sample}_1.fastq.gz"),
+        fq2=os.path.join(FASTQ_DIR, "{sample}_2.fastq.gz")
+    output:
+        html1=os.path.join(FASTQ_DIR, "qc", "{sample}_1_fastqc.html"),
+        html2=os.path.join(FASTQ_DIR, "qc", "{sample}_2_fastqc.html")
+    params:
+        outdir=os.path.join(FASTQ_DIR, "qc")
+    shell:
+        """
+        mkdir -p {params.outdir}
+        fastqc -o {params.outdir} {input.fq1} {input.fq2}
+        """
+
+rule align_bowtie2:
+    input:
+        fq1=os.path.join(FASTQ_DIR, "{sample}_1.fastq.gz"),
+        fq2=os.path.join(FASTQ_DIR, "{sample}_2.fastq.gz")
+    output:
+        bam=os.path.join(ALIGN_DIR, "{sample}.sorted.bam")
+    params:
+        index=config["reference"]["bowtie2_index"],
+        threads=config.get("threads", 8)
+    shell:
+        """
+        mkdir -p {ALIGN_DIR}
+        bowtie2 -x {params.index} -1 {input.fq1} -2 {input.fq2} --threads {params.threads} \
+            | samtools view -bS - \
+            | samtools sort -@ {params.threads} -o {output.bam}
+        """
+
+rule mark_duplicates:
+    input:
+        bam=os.path.join(ALIGN_DIR, "{sample}.sorted.bam")
+    output:
+        bam=os.path.join(ALIGN_DIR, "{sample}.dedup.bam"),
+        metrics=os.path.join(ALIGN_DIR, "{sample}.dedup.metrics.txt")
+    params:
+        threads=config.get("threads", 8)
+    shell:
+        """
+        samtools markdup -@ {params.threads} -r {input.bam} {output.bam} 2> {output.metrics}
+        """
+
+rule index_bam:
+    input:
+        os.path.join(ALIGN_DIR, "{sample}.dedup.bam")
+    output:
+        os.path.join(ALIGN_DIR, "{sample}.dedup.bam.bai")
+    shell:
+        """
+        samtools index {input}
+        """
+
+rule macs2_callpeak:
+    input:
+        treatment=lambda wildcards: os.path.join(ALIGN_DIR, f"{PAIRS[wildcards.pair]['treatment']}.dedup.bam"),
+        control=lambda wildcards: os.path.join(ALIGN_DIR, f"{PAIRS[wildcards.pair]['control']}.dedup.bam"),
+        treatment_index=lambda wildcards: os.path.join(ALIGN_DIR, f"{PAIRS[wildcards.pair]['treatment']}.dedup.bam.bai"),
+        control_index=lambda wildcards: os.path.join(ALIGN_DIR, f"{PAIRS[wildcards.pair]['control']}.dedup.bam.bai")
+    output:
+        os.path.join(PEAK_DIR, "{pair}", "{pair}_peaks.narrowPeak")
+    params:
+        genome=config["macs2"]["genome"],
+        qvalue=config["macs2"].get("qvalue", 0.01)
+    shell:
+        """
+        mkdir -p {os.path.join(PEAK_DIR, wildcards.pair)}
+        macs2 callpeak -t {input.treatment} -c {input.control} \
+            -g {params.genome} -q {params.qvalue} \
+            -n {wildcards.pair} --outdir {os.path.join(PEAK_DIR, wildcards.pair)}
+        """

--- a/ChIPSeq/config.yaml
+++ b/ChIPSeq/config.yaml
@@ -1,0 +1,24 @@
+threads: 8
+
+directories:
+  fastq: data/fastq
+  aligned: results/aligned
+  peaks: results/peaks
+
+reference:
+  bowtie2_index: /path/to/bowtie2/index/prefix
+
+macs2:
+  genome: hs
+  qvalue: 0.01
+
+samples:
+  SRR1234567:
+    sra: SRR1234567
+  SRR1234568:
+    sra: SRR1234568
+
+pairs:
+  sample1:
+    treatment: SRR1234567
+    control: SRR1234568


### PR DESCRIPTION
## Summary
- add a Snakemake pipeline that downloads SRA data, aligns reads, removes duplicates, and runs MACS2 peak calling
- provide a configurable YAML template for samples, references, and processing parameters
- document the workflow requirements and usage instructions

## Testing
- not run (pipeline definition only)


------
https://chatgpt.com/codex/tasks/task_e_690cd1d322b483208c81f90a0dc68414